### PR TITLE
Add Civilian Filters to Economic PUMS Indicators by Industry 

### DIFF
--- a/aggregate/PUMS/aggregate_PUMS.py
+++ b/aggregate/PUMS/aggregate_PUMS.py
@@ -89,7 +89,7 @@ class PUMSAggregator(BaseAggregator):
 
     def add_aggregated_data(self, new_var: pd.DataFrame):
         self.aggregated = self.aggregated.merge(
-            new_var, left_index=True, right_index=True
+            new_var, how="left", left_index=True, right_index=True
         )
 
     def assign_indicator(self, indicator) -> pd.DataFrame:

--- a/aggregate/PUMS/count_PUMS_economics.py
+++ b/aggregate/PUMS/count_PUMS_economics.py
@@ -14,7 +14,11 @@ class PUMSCountEconomics(PUMSCount):
             "civilian_employed_pop_filter",
         ),  # Termed "Employment by occupation" in data matrix
         ("lf",),
-        ("industry",),  # Termed "Employment by industry sector" in data matrix
+        (
+            "industry",
+            "civilian_employed_pop_filter",
+        ),  # Termed "Employment by industry sector" in data matrix
+        # apply civilian_employed_pop_filter
     ]
 
     def __init__(
@@ -68,9 +72,8 @@ class PUMSCountEconomics(PUMSCount):
             "Arts, Entertainment, and Recreation, and  Accommodation and Food Services": "ArtEn",
             "Other Services (except Public Administration)": "Oth",
             "Public Administration": "PbAdm",
-            "Military": "Mil",  # Note that this wasn't in field specifications but it can't hurt to add
         }
-        return f'industry-{industry_mapper.get(person["INDP"], None)}'
+        return f'industry-{industry_mapper.get(person["INDP"], "none")}'
 
     def civilian_employed_pop_filter(self, PUMS: pd.DataFrame):
         """Filter to return subset of all people ages 16-64 who are employed as civilians"""


### PR DESCRIPTION
We want to make sure we are not including any military respondents in the data - add civilian population filter and remove "military" as an industry in `count_PUMS_economics.py`. Also need to make sure that we aren't dropping columns in the join - specify "left join" in  `aggregate_PUMS.py`