### PR TITLE
demographics cv calculation

### DIFF
--- a/statistical/MOE.py
+++ b/statistical/MOE.py
@@ -6,26 +6,22 @@ import pandas as pd
 from scipy import stats
 import numpy as np
 
-z_score = stats.norm.ppf(0.9)
-
+z_score = stats.norm.ppf(0.95)
 
 def variance_measures(df, add_MOE, keep_SE):
     if add_MOE:
         df = SE_to_MOE(df)
-    if not keep_SE:
-        df = remove_SE(df)
+    df = add_CV(df) 
     return df
 
 
 def SE_to_MOE(df):
-    for c in df.columns:
-        if "-se" == c[-3:]:
-            var = c.rsplit("-", 1)[0]
-            df[f"{var}-moe"] = df[c] * z_score
-
+    df['moe'] = df['se'] * z_score
     return df
 
+def add_CV(df: pd.DataFrame):    
 
-def remove_SE(df: pd.DataFrame):
-    df.drop(columns=[c for c in df.columns if c[-3:] == "-se"], inplace=True)
-    return df
+    df['cv'] = df['se'] / df['V1'] * 100
+
+    return df 
+

--- a/statistical/MOE.py
+++ b/statistical/MOE.py
@@ -8,7 +8,7 @@ import numpy as np
 
 z_score = stats.norm.ppf(0.95)
 
-def variance_measures(df, add_MOE, keep_SE):
+def variance_measures(df, add_MOE):
     if add_MOE:
         df = SE_to_MOE(df)
     df = add_CV(df) 

--- a/statistical/calculate_counts.py
+++ b/statistical/calculate_counts.py
@@ -13,8 +13,9 @@ import rpy2.robjects as robjects
 import rpy2.robjects.packages as rpackages
 from rpy2.robjects.vectors import StrVector
 
-from statistical.MOE import variance_measures
-#from statistical.CV import 
+from statistical.variance_measures import variance_measures
+
+# from statistical.CV import
 
 survey_package = rpackages.importr("survey")
 base = rpackages.importr("base")
@@ -62,17 +63,18 @@ def calculate_counts(
         FUN=survey_package.svytotal,
         vartype=base.c("se", "ci", "var"),
     )
-    #print(aggregated)
+    # print(aggregated)
     aggregated = variance_measures(aggregated, add_MOE)
-    #print(aggregated)
+    # print(aggregated)
     """why not have all the calculation done here before moving on to the """
     aggregated.rename(
-        columns={"V1": "count", "se": "count-se", "cv": "count-cv", 'moe': 'count-moe'}, inplace=True
+        columns={"V1": "count", "se": "count-se", "cv": "count-cv", "moe": "count-moe"},
+        inplace=True,
     )
 
     pivot_table = pd.pivot_table(
         data=aggregated,
-        values=["count", "count-se", "count-cv", 'count-moe'],
+        values=["count", "count-se", "count-cv", "count-moe"],
         columns=variable_col,
         index=geo_col,
     )
@@ -90,6 +92,7 @@ def counts_to_zero(df: pd.DataFrame):
     for c in df.columns:
         if c[-6:] == "-count":
             df[c].replace({np.NaN: 0}, inplace=True)
+
 
 def remove_SE(df: pd.DataFrame):
     df.drop(columns=[c for c in df.columns if c[-3:] == "-se"], inplace=True)

--- a/statistical/calculate_counts.py
+++ b/statistical/calculate_counts.py
@@ -62,17 +62,17 @@ def calculate_counts(
         FUN=survey_package.svytotal,
         vartype=base.c("se", "ci", "var"),
     )
-    print(aggregated)
+    #print(aggregated)
     aggregated = variance_measures(aggregated, add_MOE)
-    print(aggregated)
+    #print(aggregated)
     """why not have all the calculation done here before moving on to the """
     aggregated.rename(
-        columns={"V1": "count", "se": "count-se", "cv": "count-cv"}, inplace=True
+        columns={"V1": "count", "se": "count-se", "cv": "count-cv", 'moe': 'count-moe'}, inplace=True
     )
 
     pivot_table = pd.pivot_table(
         data=aggregated,
-        values=["count", "count-se", "count-cv"],
+        values=["count", "count-se", "count-cv", 'count-moe'],
         columns=variable_col,
         index=geo_col,
     )

--- a/statistical/calculate_counts.py
+++ b/statistical/calculate_counts.py
@@ -63,10 +63,7 @@ def calculate_counts(
         FUN=survey_package.svytotal,
         vartype=base.c("se", "ci", "var"),
     )
-    # print(aggregated)
     aggregated = variance_measures(aggregated, add_MOE)
-    # print(aggregated)
-    """why not have all the calculation done here before moving on to the """
     aggregated.rename(
         columns={"V1": "count", "se": "count-se", "cv": "count-cv", "moe": "count-moe"},
         inplace=True,

--- a/statistical/calculate_fractions.py
+++ b/statistical/calculate_fractions.py
@@ -12,7 +12,7 @@ import rpy2
 import rpy2.robjects as robjects
 import rpy2.robjects.packages as rpackages
 from rpy2.robjects.vectors import DataFrame, StrVector
-from statistical.MOE import variance_measures
+from statistical.variance_measures import variance_measures
 
 survey_package = rpackages.importr("survey")
 base = rpackages.importr("base")
@@ -86,17 +86,17 @@ def calculate_fractions(
             },
             inplace=True,
         )
-        #print(single_fraction)
+        # print(single_fraction)
         single_fraction = single_fraction.apply(
             SE_to_zero_no_respondents, axis=1, result_type="expand"
         )
         all_fractions = all_fractions.merge(
             single_fraction[columns], left_index=True, right_index=True
         )
-        
+
     if not keep_SE:
         remove_SE(all_fractions)
-    
+
     return all_fractions
 
 
@@ -106,6 +106,7 @@ def SE_to_zero_no_respondents(geography):
     if not geography.iloc[0]:
         geography.iloc[1:3] = None
     return geography
+
 
 def remove_SE(df: pd.DataFrame):
     df.drop(columns=[c for c in df.columns if c[-3:] == "-se"], inplace=True)

--- a/statistical/calculate_fractions.py
+++ b/statistical/calculate_fractions.py
@@ -62,6 +62,7 @@ def calculate_fractions(
                 f"{category}-pct",
                 f"{category}-pct-se",
                 f"{category}-pct-cv",
+                f"{category}-pct-moe",
                 f"{category}-pct-denom",
             ]
         else:
@@ -69,6 +70,7 @@ def calculate_fractions(
                 f"{category}-{race_crosstab}-pct",
                 f"{category}-{race_crosstab}-pct-se",
                 f"{category}-{race_crosstab}-pct-cv",
+                f"{category}-{race_crosstab}-pct-moe",
                 f"{category}-{race_crosstab}-pct-denom",
             ]
 
@@ -79,10 +81,12 @@ def calculate_fractions(
                 "V1": columns[0],
                 "se": columns[1],
                 "cv": columns[2],
-                "denominator": columns[3],
+                "moe": columns[3],
+                "denominator": columns[4],
             },
             inplace=True,
         )
+        #print(single_fraction)
         single_fraction = single_fraction.apply(
             SE_to_zero_no_respondents, axis=1, result_type="expand"
         )
@@ -90,12 +94,10 @@ def calculate_fractions(
             single_fraction[columns], left_index=True, right_index=True
         )
         
-    all_fractions = variance_measures(all_fractions, add_MOE, keep_SE)
-    # if not keep_SE:
-    #     remove_SE(all_fractions)
-    #     return all_fractions
-    # else: 
-    #     return all_fractions
+    if not keep_SE:
+        remove_SE(all_fractions)
+    
+    return all_fractions
 
 
 def SE_to_zero_no_respondents(geography):

--- a/statistical/calculate_fractions.py
+++ b/statistical/calculate_fractions.py
@@ -53,8 +53,9 @@ def calculate_fractions(
             by=data[[geo_col]],
             design=survey_design,
             FUN=survey_package.svymean,
-            vartype=base.c("se", "ci", "var", "cv"),
+            vartype=base.c("se", "ci", "var"),
         )
+        variance_measures(single_fraction, add_MOE)
         single_fraction.drop(columns=[geo_col], inplace=True)
         if race_crosstab is None:
             columns = [
@@ -88,8 +89,13 @@ def calculate_fractions(
         all_fractions = all_fractions.merge(
             single_fraction[columns], left_index=True, right_index=True
         )
+        
     all_fractions = variance_measures(all_fractions, add_MOE, keep_SE)
-    return all_fractions
+    # if not keep_SE:
+    #     remove_SE(all_fractions)
+    #     return all_fractions
+    # else: 
+    #     return all_fractions
 
 
 def SE_to_zero_no_respondents(geography):
@@ -98,3 +104,7 @@ def SE_to_zero_no_respondents(geography):
     if not geography.iloc[0]:
         geography.iloc[1:3] = None
     return geography
+
+def remove_SE(df: pd.DataFrame):
+    df.drop(columns=[c for c in df.columns if c[-3:] == "-se"], inplace=True)
+    return df

--- a/statistical/calculate_medians.py
+++ b/statistical/calculate_medians.py
@@ -13,7 +13,7 @@ from rpy2.robjects.vectors import StrVector
 survey_package = rpackages.importr("survey")
 base = rpackages.importr("base")
 
-from statistical.MOE import variance_measures
+from statistical.variance_measures import variance_measures
 
 from rpy2.robjects import r, pandas2ri
 

--- a/statistical/variance_measures.py
+++ b/statistical/variance_measures.py
@@ -6,22 +6,23 @@ import pandas as pd
 from scipy import stats
 import numpy as np
 
-z_score = stats.norm.ppf(0.95)
+z_score = stats.norm.ppf(0.9)
+
 
 def variance_measures(df, add_MOE):
     if add_MOE:
         df = SE_to_MOE(df)
-    df = add_CV(df) 
+    df = add_CV(df)
     return df
 
 
 def SE_to_MOE(df):
-    df['moe'] = df['se'] * z_score
+    df["moe"] = df["se"] * z_score
     return df
 
-def add_CV(df: pd.DataFrame):    
 
-    df['cv'] = df['se'] / df['V1'] * 100
+def add_CV(df: pd.DataFrame):
 
-    return df 
+    df["cv"] = df["se"] / df["V1"] * 100
 
+    return df


### PR DESCRIPTION
## Overview

very simple work on the CV to follow the recipe in PFF. Apology for the very bad numbering for this branch which was directed at the issue #80 . I also created a separate issue specific to this work #179 .

## variance_measurement
added to existing MOE calculation file as a function, the cv calculation is run with the variance_measurement function. 

## calculate_count and calculate_fractions
Where the `variance_measurement` is run are moved more upstream immediately after the survey package is run. This design helps to simplify the later pivoting and renaming operations later. Also it is noted that moe was not properly added to the final results 

## keep_SE
The keep_SE flag is used to decide whether to drop all `se` columns at the end of calculation. However, it should be flagged here that the `se` columns are not included in the current implementation in `dev` regardless of the value of this flag because the final reorder columns do not include `se`. See code below for reference. It is a bigger design decision on whether the flag should be incorporated in the PUMAggregator class to keep those columns. 

https://github.com/NYCPlanning/db-equitable-development-tool/blob/1adfe2ddd1674816c5a7c4728eeecfe697ef96f2/aggregate/PUMS/aggregate_PUMS.py#L243-L249