### PR TITLE
DHS shelter indicator now reports two years, 2018 and 2020

### DIFF
--- a/aggregate/housing_security/DHS_shelter.py
+++ b/aggregate/housing_security/DHS_shelter.py
@@ -35,7 +35,6 @@ def DHS_shelter_single_year(geography, year, write_to_internal_review=False):
     )
     source_data["individuals"] = source_data["individuals"].astype(float)
     single_year = source_data.groupby(geography).sum()[["individuals"]]
-    print(single_year)
     single_year.rename(
         columns={"individuals": f"dhs_shelter_{year}_count"}, inplace=True
     )

--- a/aggregate/housing_security/DHS_shelter.py
+++ b/aggregate/housing_security/DHS_shelter.py
@@ -1,13 +1,27 @@
 """Aggregation for this indicator is unusual in that some records have borough 
 but no CD. Something to watch out for when testing"""
 
+from aggregate.load_aggregated import initialize_dataframe_geo_index
 from ingest.housing_security.DHS_shelter import load_DHS_shelter
 from internal_review.set_internal_review_file import set_internal_review_files
 from utils.CD_helpers import community_district_to_PUMA
 from utils.PUMA_helpers import borough_name_mapper
 
 
-def DHS_shelter(geography, year=2020, write_to_internal_review=False):
+def DHS_shelter(geography, write_to_internal_review=False):
+    final = initialize_dataframe_geo_index(geography)
+    for year in [2018, 2020]:
+        single_year = DHS_shelter_single_year(geography, year)
+        final = final.merge(single_year, left_index=True, right_index=True)
+    if write_to_internal_review:
+        set_internal_review_files(
+            [(final, f"DHS_shelter_{year}.csv", geography)],
+            "housing_security",
+        )
+    return final
+
+
+def DHS_shelter_single_year(geography, year, write_to_internal_review=False):
     """Main accessor"""
     source_data = load_DHS_shelter(year)
     source_data["citywide"] = "citywide"
@@ -20,11 +34,9 @@ def DHS_shelter(geography, year=2020, write_to_internal_review=False):
         source_data, "CD_code", CD_abbr_type="alpha_borough"
     )
     source_data["individuals"] = source_data["individuals"].astype(float)
-    final = source_data.groupby(geography).sum()[["individuals"]]
-    final.rename(columns={"individuals": f"DHS_shelter_{year}"}, inplace=True)
-    if write_to_internal_review:
-        set_internal_review_files(
-            [(final, f"DHS_shelter_{year}.csv", geography)],
-            "housing_security",
-        )
-    return final
+    single_year = source_data.groupby(geography).sum()[["individuals"]]
+    print(single_year)
+    single_year.rename(
+        columns={"individuals": f"dhs_shelter_{year}_count"}, inplace=True
+    )
+    return single_year


### PR DESCRIPTION
##  Main accessor now loops through 2018 and 2020

The `DHS_shelter_single_year` function in this PR used to be the main accessor. Now it's called by the new main accessor which calls it twice, once for 2018 and once for 2020. 