### PR TITLE
Fix borough level aggregation for two housing security indicators

### DIFF
--- a/aggregate/housing_security/evictions_by_city_marshals.py
+++ b/aggregate/housing_security/evictions_by_city_marshals.py
@@ -1,13 +1,21 @@
 import pandas as pd
+from internal_review.set_internal_review_file import set_internal_review_files
 from utils.PUMA_helpers import assign_PUMA_col, clean_PUMAs, borough_name_mapper
 
 
-def count_residential_evictions(geography_level, debug=False):
+def count_residential_evictions(
+    geography_level, write_to_internal_review=False, debug=False
+):
     """Main accessor of indicator"""
     residential_evictions = load_residential_evictions(debug)
     aggregated_by_geography = aggregate_by_geography(
         residential_evictions, geography_level
     )
+    if write_to_internal_review:
+        set_internal_review_files(
+            [(aggregated_by_geography, "evictions.csv", geography_level)],
+            "housing_security",
+        )
     return aggregated_by_geography
 
 
@@ -22,6 +30,11 @@ def load_residential_evictions(debug) -> pd.DataFrame:
         residential_evictions["borough"].str[0]
         + residential_evictions["borough"].str[1:].str.lower()
     )
+
+    # Hot fix, can be made neater
+    residential_evictions["borough_name"] = residential_evictions[
+        "borough_name"
+    ].replace({"Staten island": "Staten Island"})
     residential_evictions["borough"] = residential_evictions["borough_name"].map(
         borough_name_mapper
     )

--- a/internal_review/housing_security/borough/eviction_cases.csv
+++ b/internal_review/housing_security/borough/eviction_cases.csv
@@ -1,6 +1,6 @@
-borough,eviction_filings
-Bronx,339026
-Brooklyn,258668
-Manhattan,184987
-Queens,135267
-Staten Island,20400
+borough,eviction_filings_count
+BK,258668
+BX,339026
+MN,184987
+QN,135267
+SI,20400

--- a/internal_review/housing_security/borough/evictions.csv
+++ b/internal_review/housing_security/borough/evictions.csv
@@ -1,0 +1,6 @@
+borough,evictions_count
+BK,17437
+BX,21131
+MN,8276
+QN,12007
+SI,2070

--- a/utils/CD_helpers.py
+++ b/utils/CD_helpers.py
@@ -72,11 +72,11 @@ def construct_three_digit_CD_code(borough_code: str, cd_num: str) -> str:
 
 def get_borough_num_mapper():
     puma_cross = get_CD_puma_crosswalk()
-
+    puma_cross["borough_abbr"] = puma_cross["NTACode"].str[:2]
     boroughs = (
-        puma_cross[["borough_code", "borough"]]
+        puma_cross[["borough_code", "borough_abbr"]]
         .drop_duplicates()
         .set_index("borough_code")
     )
-    borough_num_mapper = boroughs.to_dict()["borough"]
+    borough_num_mapper = boroughs.to_dict()["borough_abbr"]
     return borough_num_mapper


### PR DESCRIPTION
## Issues with missing info at borough level for eviction cases and evictions by city marshals

Branch was opened to just fix eviction cases and I saw issue with evictions when checking

### Eviction cases
Issue was that conversion from numeric borough code was replacing with text of full borough name. This was fixed in `CD_helpers.get_borough_num_mapper` to set text borough as code ("BX", "MN") instead of full borough name. 

### Evictions by City Marshals
Was missing staten island evictions because boroughs are all uppercase in source data and my code to clean converted all but first letter to lowercase. This however sent "STATEN ISLAND" to "Staten island" and the lowercase "i" kept those records from being converted to "SI". This was hot-fixed, a more elegant solution would involve a case-insensitive match

