### PR TITLE
Fix geography index tests

### DIFF
--- a/aggregate/aggregation_helpers.py
+++ b/aggregate/aggregation_helpers.py
@@ -105,6 +105,20 @@ def get_category(indicator, data=None):
         return categories
 
 
+def initialize_dataframe_geo_index(geography):
+    """This should be moved to PUMA helpers and referenced in other code that merges
+    to a final dataframe"""
+    indicies = {
+        "puma": get_all_NYC_PUMAs(),
+        "borough": get_all_boroughs(),
+        "citywide": ["citywide"],
+    }
+
+    rv = pd.DataFrame(index=indicies[geography])
+    rv.index.rename(geography, inplace=True)
+    return rv
+
+
 def get_geography_pop_data(clean_data: pd.DataFrame, geography: str):
 
     if geography == "citywide":

--- a/aggregate/housing_production/hpd_housing_ny_affordable_housing.py
+++ b/aggregate/housing_production/hpd_housing_ny_affordable_housing.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 from utils.PUMA_helpers import assign_PUMA_col
 from internal_review.set_internal_review_file import set_internal_review_files
 
@@ -140,8 +141,10 @@ def PUMA_hny_units_con_type(df):
     )
 
     results = pivot_and_flatten_index(results, "puma")
-
-    return results.set_index("puma")
+    results = results.set_index("puma")
+    full_pumas = initialize_dataframe_geo_index("puma")
+    results = full_pumas.merge(results, how="left", left_index=True, right_index=True)
+    return results
 
 
 def affordable_housing(geography: str) -> pd.DataFrame:

--- a/aggregate/housing_security/DHS_shelter.py
+++ b/aggregate/housing_security/DHS_shelter.py
@@ -1,7 +1,7 @@
 """Aggregation for this indicator is unusual in that some records have borough 
 but no CD. Something to watch out for when testing"""
 
-from aggregate.load_aggregated import initialize_dataframe_geo_index
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 from ingest.housing_security.DHS_shelter import load_DHS_shelter
 from internal_review.set_internal_review_file import set_internal_review_files
 from utils.CD_helpers import community_district_to_PUMA

--- a/aggregate/housing_security/income_restricted_units.py
+++ b/aggregate/housing_security/income_restricted_units.py
@@ -54,8 +54,11 @@ def income_restricted_units_hpd(
     assert geography in ["puma", "borough", "citywide"]
 
     source_data = load_clean_hpd_data()
-    final = source_data.groupby(geography).sum()[["units_hpd_count"]]
-
+    final = initialize_dataframe_geo_index(geography)
+    aggregated = source_data.groupby(geography).sum()[["units_hpd_count"]]
+    final = final.merge(
+        aggregated, how="left", left_index=True, right_index=True
+    ).fillna(0)
     if write_to_internal_review:
         set_internal_review_files(
             [(final, "income_restricted_units_hpd.csv", geography)],

--- a/aggregate/load_aggregated.py
+++ b/aggregate/load_aggregated.py
@@ -6,7 +6,7 @@
 # from aggregate.PUMS.count_PUMS_households import PUMSCountHouseholds
 # from aggregate.PUMS.median_PUMS_economics import PUMSMedianEconomics
 from aggregate.aggregated_cache_fn import PUMS_cache_fn
-from utils.PUMA_helpers import get_all_NYC_PUMAs, get_all_boroughs
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 from utils.setup_directory import setup_directory
 from os import path
 import pandas as pd
@@ -59,20 +59,6 @@ from aggregate.clean_aggregated import rename_columns_demo
 #             del aggregator
 #         rv = rv.merge(data, left_index=True, right_index=True, how="inner")
 #     return rv
-
-
-def initialize_dataframe_geo_index(geography, columns=[]):
-    """This should be moved to PUMA helpers and referenced in other code that merges
-    to a final dataframe"""
-    indicies = {
-        "puma": get_all_NYC_PUMAs(),
-        "borough": get_all_boroughs(),
-        "citywide": ["citywide"],
-    }
-
-    rv = pd.DataFrame(index=indicies[geography], columns=columns)
-    rv.index.rename(geography, inplace=True)
-    return rv
 
 
 """this is specifically to use for housing security and quality March 4th POP data"""

--- a/aggregate/quality_of_life/heat_vulnerability.py
+++ b/aggregate/quality_of_life/heat_vulnerability.py
@@ -1,7 +1,7 @@
 import pandas as pd
-from ingest.ingestion_helpers import add_leading_zero_PUMA
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 from internal_review.set_internal_review_file import set_internal_review_files
-from utils.PUMA_helpers import get_all_boroughs
+from utils.PUMA_helpers import clean_PUMAs, get_all_boroughs
 
 
 def heat_vulnerability(geography):
@@ -19,20 +19,20 @@ def heat_vulnerability(geography):
         )
 
         print(f"Successfully loaded heat vulnerability xlsx")
+        df["puma"] = df["puma"].apply(clean_PUMAs)
 
-        df = add_leading_zero_PUMA(df)
         df = df.set_index("puma")
         print(f"Add leading zero to puma column")
 
         return df
     elif geography == "borough":
-        return pd.DataFrame(
-            index=get_all_boroughs(), columns=["health_heat_index"], data=None
-        )
+        final = initialize_dataframe_geo_index(geography)
+        final["health_heat"] = None
+
     else:
-        return pd.DataFrame(
-            index=["citywide"], columns=["health_heat_index"], data=None
-        )
+        final = initialize_dataframe_geo_index(geography)
+        final["health_heat"] = None
+    return final
 
 
 def set_results_for_internal_review(df, geography):

--- a/aggregate/quality_of_life/traffic_fatalities.py
+++ b/aggregate/quality_of_life/traffic_fatalities.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 from internal_review.set_internal_review_file import set_internal_review_files
 from utils.PUMA_helpers import (
     get_all_NYC_PUMAs,
@@ -14,12 +15,7 @@ def traffic_fatalities_injuries(geography, save_for_internal_review=False):
         ("1014", range(2010, 2015)),
         ("1620", range(2016, 2021)),
     ]
-    if geography == "puma":
-        final = pd.DataFrame(index=get_all_NYC_PUMAs())
-    if geography == "borough":
-        final = pd.DataFrame(index=get_all_boroughs())
-    if geography == "citywide":
-        final = pd.DataFrame(index=["citywide"])
+    final = initialize_dataframe_geo_index(geography)
     final.index.rename(geography, inplace=True)
 
     for year_code, year_range in year_ranges:
@@ -66,7 +62,7 @@ def get_year_range_df(year_range):
     of events. Later the calculation to get number per 100 street miles in done in mean_by_geography
 
     """
-    big_df = pd.DataFrame(data={"puma": get_all_NYC_PUMAs()})
+    big_df = initialize_dataframe_geo_index("puma")
     for year in year_range:
         raw_df = pd.read_csv(f".library/dcp_dot_trafficinjuries_{year}.csv")
         injuries_col_name = f"injuries_total_{year}"

--- a/external_review/external_review_collate.py
+++ b/external_review/external_review_collate.py
@@ -2,6 +2,7 @@
 from os import makedirs, path
 import pandas as pd
 import typer
+from aggregate.aggregation_helpers import initialize_dataframe_geo_index
 
 from aggregate.all_accessors import Accessors
 
@@ -11,17 +12,15 @@ app = typer.Typer()
 
 def collate(geography_level, category):
     """Collate indicators together"""
+    final_df = initialize_dataframe_geo_index(geography_level)
     accessor_functions = accessors.__getattribute__(category)
-    final_df = pd.DataFrame()
     for ind_accessor in accessor_functions:
         try:
             ind = ind_accessor(geography_level)
-            if final_df.empty:
-                final_df = ind
-            else:
-                final_df = final_df.merge(
-                    ind, right_index=True, left_index=True, how="left"
-                )
+
+            final_df = final_df.merge(
+                ind, right_index=True, left_index=True, how="left"
+            )
         except Exception as e:
             print(
                 f"Error merging indicator {ind_accessor.__name__} at geography level {geography_level}"

--- a/ingest/ingestion_helpers.py
+++ b/ingest/ingestion_helpers.py
@@ -1,7 +1,0 @@
-"""Miscellaneous ingestion related tasks"""
-from pandas import DataFrame
-
-
-def add_leading_zero_PUMA(df: DataFrame) -> DataFrame:
-    df["puma"] = "0" + df["puma"].astype(str)
-    return df

--- a/tests/general_indicator_tests/general_indicator_test_helpers.py
+++ b/tests/general_indicator_tests/general_indicator_test_helpers.py
@@ -5,7 +5,7 @@ accessors = Accessors()
 
 def get_by_geo():
     """housing security parameter is temporary"""
-    accessors_list = accessors.all
+    accessors_list = accessors.housing_production
     by_puma = []
     by_borough = []
     by_citywide = []

--- a/tests/general_indicator_tests/test_index_type.py
+++ b/tests/general_indicator_tests/test_index_type.py
@@ -4,23 +4,27 @@ from tests.general_indicator_tests.general_indicator_test_helpers import get_by_
 from utils.PUMA_helpers import get_all_NYC_PUMAs, get_all_boroughs
 
 all_PUMAs = get_all_NYC_PUMAs()
+all_PUMAs.sort()
 all_boroughs = get_all_boroughs()
+all_boroughs.sort()
 
 by_puma, by_borough, by_citywide = get_by_geo()
 
 
 @pytest.mark.parametrize("data, ind_name", by_puma)
 def test_all_PUMAs_present(data, ind_name):
+    returned_index = data.index
     assert (
-        data.index.values.sort() == all_PUMAs.sort()
-    ), f"not all PUMAs present for {ind_name}"
+        returned_index.sort_values() == all_PUMAs
+    ).all(), f"not all PUMAs present for {ind_name}"
 
 
 @pytest.mark.parametrize("data, ind_name", by_borough)
 def test_all_boroughs_present(data, ind_name):
+    returned_index = data.index
     assert (
-        data.index.values.sort() == all_boroughs.sort()
-    ), f"not all boroughs present for {ind_name}"
+        returned_index.sort_values() == all_boroughs
+    ).all(), f"not all boroughs present for {ind_name}"
 
 
 @pytest.mark.parametrize("data, ind_name", by_citywide)

--- a/tests/general_indicator_tests/test_tokens.py
+++ b/tests/general_indicator_tests/test_tokens.py
@@ -9,4 +9,4 @@ def test_measure_token_present(data, ind_name):
     for c in data.columns:
         assert any(
             token in c for token in ["count", "pct", "rate", "index", "median"]
-        ), f"{ind_name} returns column {c} with no count or pct token"
+        ), f"{ind_name} returns column {c} with no metric token"

--- a/utils/PUMA_helpers.py
+++ b/utils/PUMA_helpers.py
@@ -29,6 +29,20 @@ census_races = ["anh", "bnh", "hsp", "onh", "wnh"]
 dcp_pop_races = ["anh", "bnh", "hsp", "wnh"]
 
 
+def clean_PUMAs(puma) -> pd.DataFrame:
+    """Re-uses code from remove_state_code_from_PUMA col in access to subway, call this instead
+    Possible refactor: apply to dataframe and ensure that re-named column is label \"puma\" """
+    puma = str(puma)
+    puma = puma.split(".")[0]
+    if puma == "nan" or puma == nan:
+        return nan
+    elif puma[:2] == "36":
+        puma = puma[2:]
+    elif puma[0] != "0":
+        puma = "0" + puma
+    return puma
+
+
 def puma_to_borough(record):
 
     borough_code = record.puma[:3]


### PR DESCRIPTION
I needed to fix the geography tests as my blog post writes about them and people may want to look at them. Previously the tests would compare the `.sort()` method of two arrays but this method modifies the object in-place and returns None. So it was comparing None to None and always passing. 

After the tests were fixed a couple indicators were revealed as returning dataframes with missing PUMAs. This doesn't effect the output as NaN are added during the collate process but they were fixed so that tests pass. 

Updates in [PR 218](https://github.com/NYCPlanning/db-equitable-development-tool/pull/218) are in this PR as initializing an empty dataframe with a PUMA index is the best way to fix the indicators. 