### PR TITLE
Make staging directory in dump metadata

### DIFF
--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: export
         run: |
-          mkdir -p .staging/${{matrix.category}}
           poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{matrix.category}} 
           ./external_review/export_DO.sh export ${{matrix.geography}} ${{matrix.category}}
 

--- a/external_review/external_review_collate.py
+++ b/external_review/external_review_collate.py
@@ -1,4 +1,5 @@
 """Combine indicators into .csv's to be uploaded to digital ocean"""
+from os import makedirs, path
 import pandas as pd
 import typer
 
@@ -28,6 +29,9 @@ def collate(geography_level, category):
             )
             raise e
     final_df.index.rename(geography_level, inplace=True)
+    folder_path = f".staging/{category}"
+    if not path.exists(folder_path):
+        makedirs(folder_path)
     final_df.to_csv(f".staging/{category}/{category}_{geography_level}.csv")
     return final_df
 

--- a/external_review/external_review_collate.py
+++ b/external_review/external_review_collate.py
@@ -1,5 +1,4 @@
 """Combine indicators into .csv's to be uploaded to digital ocean"""
-from os import makedirs, path
 import pandas as pd
 import typer
 
@@ -29,9 +28,6 @@ def collate(geography_level, category):
             )
             raise e
     final_df.index.rename(geography_level, inplace=True)
-    folder_path = f".staging/{category}"
-    if not path.exists(folder_path):
-        makedirs(folder_path)
     final_df.to_csv(f".staging/{category}/{category}_{geography_level}.csv")
     return final_df
 

--- a/ingest/data_library/metadata.py
+++ b/ingest/data_library/metadata.py
@@ -1,4 +1,4 @@
-import os
+from os import makedirs, path
 from pathlib import Path
 
 import yaml
@@ -18,5 +18,10 @@ def add_version(dataset: str, version: str):
 
 
 def dump_metadata(category: str):
-    with open(Path(__file__).parent.parent.parent / f".staging/{category}/metadata.yml", "w") as outfile:
+    folder_path = f".staging/{category}"
+    if not path.exists(folder_path):
+        makedirs(folder_path)
+    with open(
+        Path(__file__).parent.parent.parent / f"{folder_path}/metadata.yml", "w"
+    ) as outfile:
         yaml.dump(metadata, outfile, Dumper=MyDumper, default_flow_style=False)


### PR DESCRIPTION
This is what I had in mind to keep the step to create `.staging` out of the workflow yml. I think we should avoid putting logic in the workflow yml files when we can