### PR TITLE
 poetry install update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update
 RUN apt-get -y install r-base
 # Install poetry
 RUN curl -sSL https://install.python-poetry.org | python3 -
-ENV PATH="~/.local/bin:$PATH"
+ENV PATH="~/.poetry/bin:$PATH"
 
 RUN /usr/local/bin/python3 -m pip install -U bandit
 RUN /usr/local/bin/python3 -m pip install -U black

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,8 +20,7 @@ RUN apt-get update
 #Install R
 RUN apt-get -y install r-base
 # Install poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-ENV PATH="~/.poetry/bin:$PATH"
+RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="~/.local/bin:$PATH"
 
 RUN /usr/local/bin/python3 -m pip install -U bandit

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": ". $HOME/.local/bin && poetry install",
+	"postCreateCommand": "export PATH=$PATH:$HOME/.local/bin && poetry install",
 	// Adding id_rsa so that we can push to github from the dev container
 	"initializeCommand": "ssh-add $HOME/.ssh/id_rsa",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": ". $HOME/.poetry/env && poetry install",
+	"postCreateCommand": ". $HOME/.local/bin && poetry install",
 	// Adding id_rsa so that we can push to github from the dev container
 	"initializeCommand": "ssh-add $HOME/.ssh/id_rsa",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -40,7 +40,7 @@ jobs:
           sudo apt update
           sudo apt install -y python3-pip python3-distutils
           sudo apt install -y gdal-bin
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
           sudo mv ./mc /usr/bin
@@ -48,8 +48,8 @@ jobs:
 
       - name: Poetry Install
         run: |
-          . $HOME/.poetry/env
-          pip install poetry
+          export PATH=$PATH:$HOME/.local/bin
+          
           poetry install      
 
       - name: dataloading

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Poetry Install
         run: |
           export PATH=$PATH:$HOME/.local/bin
-          
           poetry install      
 
       - name: dataloading

--- a/.github/workflows/export_census.yml
+++ b/.github/workflows/export_census.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Poetry Install
         run: |
           export PATH=$PATH:$HOME/.local/bin
-          
           poetry install      
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/export_census.yml
+++ b/.github/workflows/export_census.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-distutils
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
           sudo mv ./mc /usr/bin
@@ -48,8 +48,8 @@ jobs:
 
       - name: Poetry Install
         run: |
-          . $HOME/.poetry/env
-          pip install poetry
+          export PATH=$PATH:$HOME/.local/bin
+          
           poetry install      
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/test_PUMS_aggregation.yml
+++ b/.github/workflows/test_PUMS_aggregation.yml
@@ -25,12 +25,12 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-distutils
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Poetry Install
         run: |
-          . $HOME/.poetry/env
-          pip install poetry
+          export PATH=$PATH:$HOME/.local/bin
+          
           poetry install
 
       - uses: r-lib/actions/setup-r@v1
@@ -45,5 +45,5 @@ jobs:
 
       - name: Pytest
         run: |
-          . $HOME/.poetry/env
+          export PATH=$PATH:$HOME/.local/bin
           poetry run pytest -s -q --all_data -m test_aggregation tests/PUMS 

--- a/.github/workflows/test_PUMS_aggregation.yml
+++ b/.github/workflows/test_PUMS_aggregation.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Poetry Install
         run: |
           export PATH=$PATH:$HOME/.local/bin
-          
           poetry install
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/test_PUMS_download.yml
+++ b/.github/workflows/test_PUMS_download.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Poetry Install
         run: |
           export PATH=$PATH:$HOME/.local/bin
-          
           poetry install
 
       - uses: r-lib/actions/setup-r@v1

--- a/.github/workflows/test_PUMS_download.yml
+++ b/.github/workflows/test_PUMS_download.yml
@@ -24,12 +24,12 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-distutils
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
 
       - name: Poetry Install
         run: |
-          . $HOME/.poetry/env
-          pip install poetry
+          export PATH=$PATH:$HOME/.local/bin
+          
           poetry install
 
       - uses: r-lib/actions/setup-r@v1
@@ -44,5 +44,5 @@ jobs:
 
       - name: Pytest
         run: |
-          . $HOME/.poetry/env
+          export PATH=$PATH:$HOME/.local/bin
           poetry run pytest -s -q --all_data -m test_download tests/PUMS

--- a/.github/workflows/test_indicators.yml
+++ b/.github/workflows/test_indicators.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Poetry Install
         run: |
           export PATH=$PATH:$HOME/.local/bin
-          
           poetry install
       
       - name: dataloading

--- a/.github/workflows/test_indicators.yml
+++ b/.github/workflows/test_indicators.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y python3-pip python3-distutils
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
           sudo mv ./mc /usr/bin
@@ -36,8 +36,8 @@ jobs:
 
       - name: Poetry Install
         run: |
-          . $HOME/.poetry/env
-          pip install poetry
+          export PATH=$PATH:$HOME/.local/bin
+          
           poetry install
       
       - name: dataloading
@@ -45,5 +45,5 @@ jobs:
 
       - name: Pytest
         run: |
-          . $HOME/.poetry/env
+          export PATH=$PATH:$HOME/.local/bin
           poetry run pytest -v tests/general_indicator_tests


### PR DESCRIPTION
#301 

Poetry installation failed in one of the recent GitHub Actions test runs. It them comes to light according to [poetry documentation](https://python-poetry.org/docs/#installation), the installation procedure we being relying on is now deprecated. Along with the new url, the path where poetry gets installed also changed so new path also needs to be added. 

I did [an export](https://github.com/NYCPlanning/db-equitable-development-tool/actions/runs/2972659931) with this feature branch to prove that the new installation worked but feel free to run more extensive tests on this with Actions. 