### PR TITLE
308 upgrade export category workflow

### DIFF
--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -34,10 +34,10 @@ jobs:
           - puma
           - borough
           - citywide
-        category:
-          - housing_production
-          - quality_of_life
-          - housing_security
+#        category:
+#          - housing_production
+#          - quality_of_life
+#          - housing_security
  
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: export
         run: |
-          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.category}}  
-          ./external_review/export_DO.sh export ${{matrix.geography}} ${{github.event.inputs.category}}
+          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.options.category}}  
+          ./external_review/export_DO.sh export ${{matrix.geography}} ${{github.event.inputs.options.category}}
 
 

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -28,16 +28,16 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       
-    strategy:
-      matrix:
-        geography:
-          - puma
-          - borough
-          - citywide
-        category:
-          - housing_production
-          - quality_of_life
-          - housing_security
+#    strategy:
+#      matrix:
+#        geography:
+#          - puma
+#          - borough
+#          - citywide
+#        category:
+#          - housing_production
+#          - quality_of_life
+#          - housing_security
  
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -11,14 +11,7 @@ on:
         - housing_production
         - quality_of_life
         - housing_security
-#    geography:
-#        description: 'Pick Geography to Export.'
-#        required: False
-#        type: choice
-#        options:
-#        - citywide
-#        - borough
-#        - puma
+
 
 jobs:
   export:
@@ -34,10 +27,6 @@ jobs:
           - puma
           - borough
           - citywide
-#        category:
-#          - housing_production
-#          - quality_of_life
-#          - housing_security
  
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -3,11 +3,21 @@ name: Export Category
 on:
   workflow_dispatch:
     inputs:
+      type: choice
       category:
-        description: 'Corresponds to tab of 1572-B data matrix '
+        description: 'Pick Category to Export. This corresponds to tabs in the 1572-B data matrix '
         required: true
-        default: housing_production
-
+        options:
+        - housing_production
+        - quality_of_life
+        - housing_security
+      geography:
+        description: Pick Geography to Export (citywide, borough, puma).
+        required: False
+        options:
+        - citywide
+        - borough
+        - puma
 
 jobs:
   export:
@@ -25,7 +35,7 @@ jobs:
           - citywide
         category:
           - housing_production
-          #- quality_of_life
+          - quality_of_life
           - housing_security
  
     steps:

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -3,10 +3,10 @@ name: Export Category
 on:
   workflow_dispatch:
     inputs:
-      type: choice
       category:
         description: 'Pick Category to Export. This corresponds to tabs in the 1572-B data matrix '
         required: true
+        type: choice
         options:
         - housing_production
         - quality_of_life
@@ -14,6 +14,7 @@ on:
       geography:
         description: Pick Geography to Export (citywide, borough, puma).
         required: False
+        type: choice
         options:
         - citywide
         - borough

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: export
         run: |
-          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{matrix.category}} 
-          ./external_review/export_DO.sh export ${{matrix.geography}} ${{matrix.category}}
+          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{inputs.matrix.category}} 
+          ./external_review/export_DO.sh export ${{matrix.geography}} ${{inputs.matrix.category}}
 
 

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -12,7 +12,7 @@ on:
         - quality_of_life
         - housing_security
       geography:
-        description: Pick Geography to Export (citywide, borough, puma).
+        description: 'Pick Geography to Export (citywide, borough, puma).'
         required: False
         type: choice
         options:

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: export
         run: |
-          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.options.category}}  
-          ./external_review/export_DO.sh export ${{matrix.geography}} ${{github.event.inputs.options.category}}
+          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.category}}  
+          ./external_review/export_DO.sh export ${{matrix.geography}} ${{github.event.inputs.category}}
 
 

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -68,6 +68,6 @@ jobs:
       - name: export
         run: |
           poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.category}}  
-          ./external_review/export_DO.sh export ${{matrix.geography}} ${{matrix.category}}
+          ./external_review/export_DO.sh export ${{matrix.geography}} ${{github.event.inputs.category}}
 
 

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -11,14 +11,14 @@ on:
         - housing_production
         - quality_of_life
         - housing_security
-      geography:
-        description: 'Pick Geography to Export (citywide, borough, puma).'
-        required: False
-        type: choice
-        options:
-        - citywide
-        - borough
-        - puma
+#    geography:
+#        description: 'Pick Geography to Export.'
+#        required: False
+#        type: choice
+#        options:
+#        - citywide
+#        - borough
+#        - puma
 
 jobs:
   export:
@@ -28,16 +28,16 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       
-#    strategy:
-#      matrix:
-#        geography:
-#          - puma
-#          - borough
-#          - citywide
-#        category:
-#          - housing_production
-#          - quality_of_life
-#          - housing_security
+    strategy:
+      matrix:
+        geography:
+          - puma
+          - borough
+          - citywide
+        category:
+          - housing_production
+          - quality_of_life
+          - housing_security
  
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/export_category.yml
+++ b/.github/workflows/export_category.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: export
         run: |
-          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{inputs.matrix.category}} 
-          ./external_review/export_DO.sh export ${{matrix.geography}} ${{inputs.matrix.category}}
+          poetry run python3 -m external_review.external_review_collate ${{matrix.geography}} ${{github.event.inputs.category}}  
+          ./external_review/export_DO.sh export ${{matrix.geography}} ${{matrix.category}}
 
 


### PR DESCRIPTION
This PR addresses issue #308.

We wanted to have the ability to pick which category to export from the Github Action Workflow. In this PR, you can now pick which category to export from a dropdown menu. Further improvements can be made to where we set up a dropdown menu for geography but default to all geo's.

I recommend running the action and then viewing the output in DO to test.

Here are is action I [ran](https://github.com/NYCPlanning/db-equitable-development-tool/actions/runs/3069451766/jobs/4958125138)


