### PR TITLE
fix dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "export PATH=$PATH:$HOME/.local/bin && poetry install",
 	// Adding id_rsa so that we can push to github from the dev container
-	"initializeCommand": "./bash/setup_devcontainer.sh",
+	"initializeCommand": "./utils/setup_devcontainer.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode",
 	//The following is not in facdb's version of this file

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "export PATH=$PATH:$HOME/.local/bin && poetry install",
 	// Adding id_rsa so that we can push to github from the dev container
-	"initializeCommand": "ssh-add $HOME/.ssh/id_rsa",
+	"initializeCommand": "ssh-add",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode",
 	//The following is not in facdb's version of this file

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "export PATH=$PATH:$HOME/.local/bin && poetry install",
 	// Adding id_rsa so that we can push to github from the dev container
-	"initializeCommand": "ssh-add",
+	"initializeCommand": "./bash/setup_devcontainer.sh",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode",
 	//The following is not in facdb's version of this file

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -1,6 +1,13 @@
 name: Branch tests
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths:
+      - ".devcontainer/**"
+      - "utils/**"
+      - "requirements.in"
+      - "requirements.txt"
+  workflow_dispatch:
 
 jobs:
   branch_dev_container_tests:

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -1,6 +1,6 @@
 name: Branch tests
 
-on: [push, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   branch_dev_container_tests:

--- a/.github/workflows/test_branch.yml
+++ b/.github/workflows/test_branch.yml
@@ -1,0 +1,15 @@
+name: Branch tests
+
+on: [push, workflow_dispatch]
+
+jobs:
+  branch_dev_container_tests:
+    name: Dev container tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: echo "CI environment variable is $CI"
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: pip list

--- a/utils/setup_build_env.sh
+++ b/utils/setup_build_env.sh
@@ -5,8 +5,8 @@ set -e
 
 apt-get update
 
-# # Install R
-# apt-get -y install r-base
+# Install R
+apt-get -y install r-base
 
 # Install python packages
 python3 -m pip install --upgrade pip

--- a/utils/setup_devcontainer.sh
+++ b/utils/setup_devcontainer.sh
@@ -6,5 +6,6 @@ set -e
 # Skip when called in a github action workflow
 if [[ !$CI == "true" ]]; then
     # Add id_rsa so that we can push to github from the dev container
-    ssh-add $HOME/.ssh/id_rsa
+    # ssh-add $HOME/.ssh/id_rsa
+    ssh-add
 fi

--- a/utils/setup_devcontainer.sh
+++ b/utils/setup_devcontainer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Sets up enviroment for dev in local devcontainer.
+set -e
+
+# Skip when called in a github action workflow
+if [[ !$CI == "true" ]]; then
+    # Add id_rsa so that we can push to github from the dev container
+    ssh-add $HOME/.ssh/id_rsa
+fi


### PR DESCRIPTION
## motivations
* per issues in #320 and wider-scale improvements in #321, it may be nice to first fix the broken dev container
* likely due to changes from #319 

## changes
* undo removal of R install in `setup_build_env.sh`
  * since subsequent python package installs need it (even if the packages aren't currently used in scripts we run)
* add a github test to build the dev container in CI
* skip the `ssh-add` step of the dev container build during the test using a [github default environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) which is always true

## notes
* new dev container test [fails quickly](https://github.com/NYCPlanning/db-equitable-development-tool/actions/runs/4576260772/jobs/8080153656#step:4:537) (1m 22s)